### PR TITLE
#166798815 Fix Search Button Inconsistent Behaviour

### DIFF
--- a/UI/js/listed_properties.js
+++ b/UI/js/listed_properties.js
@@ -131,6 +131,7 @@ const initPropertiesWrapper = () => {
     contentBox.insertAdjacentHTML('afterbegin', markup);
     searchField = document.querySelector('#search-form input[type="text"]');
     searchButton = document.querySelector('#search-form input[type="submit"]');
+    searchButton.addEventListener('click', handleSearch);
     searchField.addEventListener('focus', () => searchFieldHasFocus = true);
     searchField.addEventListener('blur', () => searchFieldHasFocus = false);
     propertiesWrapper = document.querySelector('.properties-wrapper');


### PR DESCRIPTION
#### What does this PR do?
Solve inconsistent behaviour of the search button click event

#### Description of Task to be completed?
Have the search button click event render search results on the screen

#### How should this be manually tested?
Clone this repo, checkout into bg-search-button-click--166798815, cd into UI, open listed_properties.html in a browser, enter search text into the search box and click on the search button

#### Any background context you want to provide?
User should be able to see properties of a specific type

#### What are the relevant pivotal tracker stories?
[#166798815, #166667504]

#### Screenshots (if appropriate)
None

#### Questions:
None

[Fixes #166798815, Finishes #166667504]