### PR TITLE
#166667106 Implement Marking Property as Sold

### DIFF
--- a/UI/css/listed_properties.css
+++ b/UI/css/listed_properties.css
@@ -316,6 +316,38 @@ input:focus {
     margin-bottom: 40px;
 }
 
+.property-details-wrapper .status-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+div.toggle-status {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+div.toggle-status.sold {
+    border: 2px solid #f00;
+}
+
+div.toggle-status.available {
+    border: 2px solid var(--primary-color);
+}
+
+.status-wrapper .property-status-toggler {
+    line-height: 1.4em;
+    height: 20px;
+    width: 20px;
+    margin-right: 20px;
+}
+
+div.no-display {
+    display: none;
+}
+
 @media screen and (min-width: 768px) {
     .contents {
         padding: var(--content-padding-medium);

--- a/UI/js/listed_properties.js
+++ b/UI/js/listed_properties.js
@@ -10,6 +10,7 @@ let nextImageButton;
 let previousImageButton;
 let propertyImageList;
 let propertyImage;
+let propertyStatusToggler;
 
 // User model
 class User {
@@ -229,6 +230,17 @@ const displayPreviousPropertyImage = () => {
     }
 };
 
+/**
+ * Handles @var propertyStatusToggler's click event and toggles @member sold
+ * @memberof Property
+ */
+const togglePropertyStatus = () => {
+    const propertyId = parseInt(window.location.hash.substring(1).split('=')[1]);
+    const property = properties.find(el => el.propertyId === propertyId);
+    property.sold = propertyStatusToggler.checked;
+    clearContentBox();
+    renderPropertyDetails(propertyId);
+};
 
 /**
  * Renders the details of a specific property on the screen. Obtains the
@@ -241,13 +253,25 @@ const displayPreviousPropertyImage = () => {
  */
 const renderPropertyDetails = propertyId => {
     const property = properties.find(el => el.propertyId === propertyId);
+    const propertyStatus = property.sold;
     propertyImageList = property.images;
     const agent = users.find(el => el.userId === property.agentId);
+    const userOwnsAd = agent.userId === currentUser.userId;
     const markup = `
         <div class="details-wrapper">
             <div class="property-details-wrapper">
                 <h2 class="title">${property.title}</h2>
-                <p>Status: <span class="status text--capitalized">${property.sold ? "sold" : "available"}</span></p>
+                <div class="status-wrapper">
+                    <p>Status: <span class="status text--capitalized">
+                        ${propertyStatus ? "sold" : "available"}
+                    </span></p>
+
+                    <div class="${userOwnsAd ? '' : "no-display "}${propertyStatus ? "sold " : "available "}toggle-status">
+                        <input type="checkbox" name="property-status-toggler"
+                            class="property-status-toggler" ${property.sold ? "checked" : null}>
+                        <label for="property-status-toggler" class="text--capitalized">Mark as sold</label>
+                    </div>
+                </div>
                 <div class="img-wrapper">
                     <div class="prev-img">
                         <div></div>
@@ -296,6 +320,11 @@ const renderPropertyDetails = propertyId => {
     previousImageButton = document.querySelector('.prev-img div');
     nextImageButton.addEventListener('click', displayNextPropertyImage);
     previousImageButton.addEventListener('click', displayPreviousPropertyImage);
+    
+    if (userOwnsAd) {
+        propertyStatusToggler = document.querySelector('div.toggle-status input');
+        propertyStatusToggler.addEventListener('click', togglePropertyStatus)
+    }
 };
 
 /**


### PR DESCRIPTION
#### What does this PR do?
Provides user (agent) with an interface (in detail view) to mark his/her posted property ads as sold

#### Description of Task to be completed?
Implement a checkbox in property detail view by which user can mark a property as sold

#### How should this be manually tested?
After cloning this repo, checkout into develop, cd into UI, open listed_properties.html in a browser, click any property ad whose agentId equals current user userId (e.g. last property in the list)

#### Any background context you want to provide?
User (agent) should be able to mark his/her posted property ads as sold

#### What are the relevant pivotal tracker stories?
#166667106

#### Screenshots (if appropriate)
![Screenshot (20)](https://user-images.githubusercontent.com/36412651/59891625-bf629b00-93cd-11e9-9824-af6e5e104f3b.png)
![Screenshot (19)](https://user-images.githubusercontent.com/36412651/59891637-c7bad600-93cd-11e9-88a1-016ef15aeeae.png)

#### Questions:
None