### PR TITLE
#166667300 Implement Property Deletion

### DIFF
--- a/UI/css/listed_properties.css
+++ b/UI/css/listed_properties.css
@@ -49,6 +49,7 @@ a {
     height: 40px;
     position: relative;
     transition: left 0.3s ease;
+    z-index: 2;
 }
 
 .hamburger-wrapper .toggler {
@@ -341,12 +342,96 @@ div.toggle-status.available {
     line-height: 1.4em;
     height: 20px;
     width: 20px;
-    margin-right: 20px;
+    margin-right: 10px;
 }
 
 div.no-display {
     display: none;
 }
+
+.delete-btn {
+    background: #cf3226;
+    width: 100px;
+    height: 40px;
+    font-weight: 600;
+    font-size: 1.2em;
+    margin-top: 50px;
+    border-radius: 5px;
+    border: 1px solid transparent;
+    outline: none;
+}
+
+
+
+/* =======================
+        DELETE MODAL 
+   =======================        
+*/
+.modal {
+    background-color: rgba(0, 0, 0, 0.5);
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 3;
+}
+
+.modal .modal-content {
+    width: 90%;
+    max-width: 500px;
+    background: #fff;
+    text-align: center;
+}
+.modal .modal-header {
+    /* background: gray; */
+    /* background: #85929E99; */
+    background: var(--primary-color-light);
+    padding: 20px;
+    color: #fff;
+}
+
+.modal .modal-body {
+    padding: 60px;
+    width: 60%;
+    margin: 0 auto;
+}
+
+.modal .modal-body .message {
+    margin-bottom: 30px;
+}
+
+.modal .modal-body .property-title {
+    font-weight: 600;
+}
+
+.modal .buttons {
+    display: flex;
+    justify-content: space-around;
+}
+
+.modal button {
+    width: 90px;
+    height: 40px;
+    border-radius: 5px;
+    border: 1px solid transparent;
+    color: #fff;
+    font-size: 1.2em;
+    font-weight: 400;
+}
+
+.modal button.cancel-delete {
+    background: #85929E;
+}
+
+.modal button.confirm-delete {
+    background: #cf3226;
+}
+
 
 @media screen and (min-width: 768px) {
     .contents {

--- a/UI/listed_properties.html
+++ b/UI/listed_properties.html
@@ -59,6 +59,30 @@
         </main>
     </div>
 
+
+    <div class="modal no-display">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>
+                    Delete Property
+                </h2>
+            </div>
+            <div class="modal-body">
+                <p class="message">
+                    Delete <span class="property-title">
+                        
+                    </span>?
+                </p>
+                            
+                <div class="buttons">
+                    <button class="cancel-delete">Cancel</button>
+                    <button class="confirm-delete">Confirm</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
     <script src="./js/listed_properties.js"></script>
 </body>
 </html>


### PR DESCRIPTION
#### What does this PR do?
Provides the interface to enable user (agent) delete a his/her property ad

#### Description of Task to be completed?
- Provide a delete button on the property detail page so user can delete the ad
- Display a modal to confirm or cancel deletion

#### How should this be manually tested?
Clone this repo, checkout into the develop branch, cd into UI, open listed_properties.html in a browser, click any property ad with the current user userId as agentId (e.g. the last), click delete button on the detail page and confirm delete in the modal

#### Any background context you want to provide?
User (agent) should be able to delete his/her posted property ad

#### What are the relevant pivotal tracker stories?
#166667300

#### Screenshots (if appropriate)
![Screenshot (21)](https://user-images.githubusercontent.com/36412651/59905881-36fcee00-93ff-11e9-9dd3-36c5dca19d75.png)
![Screenshot (24)](https://user-images.githubusercontent.com/36412651/59905884-395f4800-93ff-11e9-8b05-cc068c262895.png)

#### Questions:
None