### PR TITLE
#166847994 Fix Property Delete and Edit Options Display

### DIFF
--- a/UI/css/listed_properties.css
+++ b/UI/css/listed_properties.css
@@ -351,6 +351,10 @@ div.toggle-status.available {
     margin-right: 10px;
 }
 
+.details-wrapper  div.no-display.buttons {
+    display: none;
+}
+
 div.no-display {
     display: none;
 }


### PR DESCRIPTION
#### What does this PR do?
This commit fixes the delete and edit options showing for non-owners

#### Description of Task to be completed?
Solve element block display type in UI/css/listed_properties.css

#### How should this be manually tested?
Clone the repo, cd into UI, open listed_properties.html in a browser, click on the first ad on the list (or any other that has not its agentId as the current user's userId)

#### Any background context you want to provide?
User (agent) should be to update his/her property ad

#### What are the relevant pivotal tracker stories?
#166847994, #166666181

#### Screenshots (if appropriate)
![Screenshot (27)](https://user-images.githubusercontent.com/36412651/59938999-7a327d80-944e-11e9-84de-5aa9bf6f548f.png)

#### Questions:
None


[Finishes #166847994 ,#166666181]