### PR TITLE
#167060983 Implement Property Update Endpoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,5 @@ module.exports = {
     "rules": {
         "linebreak-style": 0,
         "consistent-return": 0,
-        "import/prefer-default-export": 0,
     }
 };

--- a/server/helpers/property.js
+++ b/server/helpers/property.js
@@ -90,11 +90,11 @@ export const getPropertyDetails = (property) => {
 /**
  * Filters the list of property by a given query text and returns an
  * appropriate response or error message
- * 
+ *
  * @param {*} response
  * @param {Array} properties
  * @param {string} queryText
- * 
+ *
  * @returns {response}
  */
 export const filterPropertiesByType = (response, properties, queryText) => {

--- a/server/helpers/property.js
+++ b/server/helpers/property.js
@@ -32,9 +32,13 @@ const hasNumber = value => /\d/.test(value);
 /**
  * Passes the fields in a request body validating each and returning
  * an appropriate error message or false
- * @param {object} param
+ * Calls @function isString, @function isNumber, @function hasNumber
+ *
+ * @param {object}
+ *
+ * @returns {string | boolean}
  */
-export const getPostPropertyError = ({
+export const getCreatePropertyError = ({
   type, state, city, address, price,
 }) => {
   if (!isString(type)) {
@@ -112,4 +116,58 @@ export const filterPropertiesByType = (response, properties, queryText) => {
     status: 'success',
     data,
   });
+};
+
+
+/**
+ * Checks through the body of a property update request for empty
+ * required fields, and invalid fields
+ *
+ * @param {object}
+ *
+ * @returns {string | boolean}
+ */
+export const getUpdatePropertyError = ({
+  type, state, city, address, price,
+}) => {
+  if (isString(type) && !type.trim()) {
+    // there's an empty type field
+    return 'Type cannot be empty';
+  } if (isString(state) && !state.trim()) {
+    // there's an empty state field
+    return 'State cannot be empty';
+  } if (state && (!isString(state) || hasNumber(state))) {
+    // there's an invalid state field
+    return 'Invalid state field';
+  } if (isString(city) && !city.trim()) {
+    // there's an empty city field
+    return 'City cannot be empty';
+  } if (city && (!isString(city) || hasNumber(city))) {
+    // there's an invalid city field
+    return 'Invalid city field';
+  } if (isString(address) && !address.trim()) {
+    // there's an empty address field
+    return 'Address cannot be empty';
+  } if (address && (!isString(address) || isNumber(address))) {
+    // there's an invalid address field
+    return 'Invalid address field';
+  } if (price !== undefined && (
+    price === '' || !isNumber(price) || parseFloat(price) <= 0)) {
+    // price field is: '' | non-number | < 0
+    return 'Invalid price field';
+  }
+  return false;
+};
+
+
+/**
+ * Checks the body of a property update request if it contains an "id"
+ * or/and an "owner" field
+ * @param {object} body
+ *
+ * @returns {boolean}
+ */
+export const hasForbiddenField = (body) => {
+  const keys = Object.keys(body);
+  return keys.includes('id') || keys.includes('owner');
 };

--- a/server/routes/property.js
+++ b/server/routes/property.js
@@ -5,12 +5,21 @@ import checkAuth from '../middleware/check_auth';
 import imageUploader from '../middleware/image_upload';
 import validatePropertyId from '../middleware/validate_property_id';
 
+
 const router = Router();
 
 router.post('/', checkAuth, imageUploader, propertyController.createProperty);
+
 router.get('/', checkAuth, propertyController.getProperties);
-router.get('/:propertyId', checkAuth, validatePropertyId, propertyController.getPropertyById);
-router.patch('/:propertyId/sold', checkAuth, validatePropertyId, propertyController.markPropertyAsSold);
+
+router.get('/:propertyId', checkAuth, validatePropertyId,
+  propertyController.getPropertyById);
+
+router.patch('/:propertyId/sold', checkAuth, validatePropertyId,
+  propertyController.markPropertyAsSold);
+
+router.patch('/:propertyId', checkAuth, validatePropertyId,
+  imageUploader, propertyController.updateProperty);
 
 
 export default router;

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -1,10 +1,11 @@
 import signupTests from './signup.test';
 import signinTests from './signin.test';
-import postPropertyTests from './create_property.test';
+import createPropertyAdTests from './create_property.test';
 import getAllPropertiesTests from './get_all_properties.test';
 import getPropertyByIdTests from './get_property.test';
 import markPropertyAsSoldTests from './mark_sold.test';
 import queryPropertyTypeTests from './search_property_by_type.test';
+import updatePropertyAdTests from './update_property.test';
 
 
 // Tests for signup requests
@@ -14,7 +15,7 @@ describe('POST /api/v1/auth/signup', signupTests);
 describe('POST /api/v1/auth/signin', signinTests);
 
 // Tests for create property ad requests
-describe('POST /api/v1/property', postPropertyTests);
+describe('POST /api/v1/property', createPropertyAdTests);
 
 // Tests for get all properties requests
 describe('GET /api/v1/property', getAllPropertiesTests);
@@ -25,4 +26,8 @@ describe('GET /api/v1/property/<:propertyId>', getPropertyByIdTests);
 // Tests for marking a property ad as sold
 describe('PATCH /api/v1/property/<:propertyId>/sold', markPropertyAsSoldTests);
 
+// Tests for property list search
 describe('GET /api/v1/property?type=queryText', queryPropertyTypeTests);
+
+// Tests for property update
+describe('PATCH /api/v1/property/<:propertyId>', updatePropertyAdTests);

--- a/server/test/update_property.test.js
+++ b/server/test/update_property.test.js
@@ -481,7 +481,7 @@ export default () => {
           .patch(`${propertyUrl}/${propertyEntries[1].id}`)
           .set('Content-Type', 'multipart/form-data')
           .set('Authorization', `Bearer ${agentOne.token}`)
-          .field('address', '3928df');
+          .field('price', '3928df');
 
         expect(res.status).to.equal(400);
         expect(res.body).to.be.an('object');
@@ -497,7 +497,7 @@ export default () => {
           .patch(`${propertyUrl}/${propertyEntries[1].id}`)
           .set('Content-Type', 'multipart/form-data')
           .set('Authorization', `Bearer ${agentOne.token}`)
-          .field('address', 0);
+          .field('price', 0);
 
         expect(res.status).to.equal(400);
         expect(res.body).to.be.an('object');
@@ -511,6 +511,7 @@ export default () => {
       const res = await chai.request(app)
         .patch(`${propertyUrl}/${propertyEntries[1].id}`)
         .set('Content-Type', `Bearer ${agentOne.token}`)
+        .set('Authorization', `Bearer ${agentOne.token}`)
         .field('id', 1);
 
       expect(res.status).to.equal(403);
@@ -519,7 +520,7 @@ export default () => {
       expect(res.body.status).to.equal('error');
       expect(res.body).to.have.property('error');
       expect(res.body.error).to.equal(
-        'You cannot update forbidden fields: "id", "owner", and dates',
+        'You cannot update fields "id" and "owner"',
       );
     });
 
@@ -527,6 +528,7 @@ export default () => {
       const res = await chai.request(app)
         .patch(`${propertyUrl}/${propertyEntries[1].id}`)
         .set('Content-Type', `Bearer ${agentOne.token}`)
+        .set('Authorization', `Bearer ${agentOne.token}`)
         .field('owner', 2);
 
       expect(res.status).to.equal(403);
@@ -535,39 +537,7 @@ export default () => {
       expect(res.body.status).to.equal('error');
       expect(res.body).to.have.property('error');
       expect(res.body.error).to.equal(
-        'You cannot update forbidden fields: "id", "owner", and dates',
-      );
-    });
-
-    it('should fail to update property creation date', async () => {
-      const res = await chai.request(app)
-        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
-        .set('Content-Type', `Bearer ${agentOne.token}`)
-        .field('createdOn', new Date());
-
-      expect(res.status).to.equal(403);
-      expect(res.body).to.be.an('object');
-      expect(res.body).to.have.property('status');
-      expect(res.body.status).to.equal('error');
-      expect(res.body).to.have.property('error');
-      expect(res.body.error).to.equal(
-        'You cannot update forbidden fields: "id", "owner", and dates',
-      );
-    });
-
-    it('should fail to update property update date', async () => {
-      const res = await chai.request(app)
-        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
-        .set('Content-Type', `Bearer ${agentOne.token}`)
-        .field('updatedOn', null);
-
-      expect(res.status).to.equal(403);
-      expect(res.body).to.be.an('object');
-      expect(res.body).to.have.property('status');
-      expect(res.body.status).to.equal('error');
-      expect(res.body).to.have.property('error');
-      expect(res.body.error).to.equal(
-        'You cannot update forbidden fields: "id", "owner", and dates',
+        'You cannot update fields "id" and "owner"',
       );
     });
   });

--- a/server/test/update_property.test.js
+++ b/server/test/update_property.test.js
@@ -506,5 +506,69 @@ export default () => {
         expect(res.body).to.have.property('error');
         expect(res.body.error).to.equal('Invalid price field');
       });
+
+    it('should fail to update property id', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+        .set('Content-Type', `Bearer ${agentOne.token}`)
+        .field('id', 1);
+
+      expect(res.status).to.equal(403);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('error');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.equal(
+        'You cannot update forbidden fields: "id", "owner", and dates',
+      );
+    });
+
+    it('should fail to update property owner', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+        .set('Content-Type', `Bearer ${agentOne.token}`)
+        .field('owner', 2);
+
+      expect(res.status).to.equal(403);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('error');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.equal(
+        'You cannot update forbidden fields: "id", "owner", and dates',
+      );
+    });
+
+    it('should fail to update property creation date', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+        .set('Content-Type', `Bearer ${agentOne.token}`)
+        .field('createdOn', new Date());
+
+      expect(res.status).to.equal(403);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('error');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.equal(
+        'You cannot update forbidden fields: "id", "owner", and dates',
+      );
+    });
+
+    it('should fail to update property update date', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+        .set('Content-Type', `Bearer ${agentOne.token}`)
+        .field('updatedOn', null);
+
+      expect(res.status).to.equal(403);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('error');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.equal(
+        'You cannot update forbidden fields: "id", "owner", and dates',
+      );
+    });
   });
 };

--- a/server/test/update_property.test.js
+++ b/server/test/update_property.test.js
@@ -134,7 +134,7 @@ export default () => {
   });
 
   describe('success', () => {
-    it('should update property ad data successfully', async () => {
+    it('should update property ad price successfully', async () => {
       const res = await chai.request(app)
         .patch(`${propertyUrl}/${propertyEntries[0].id}`)
         .set('Content-Type', 'multipart/form-data')
@@ -157,12 +157,115 @@ export default () => {
       expect(res.body.data).to.have.property('createdOn');
       expect(res.body.data).to.have.property('updatedOn');
       expect(res.body.data).to.have.property('imageUrl');
-      expect(res.body.data.status).to.equal(propertyEntries[0].status);
-      expect(res.body.data.type).to.equal(propertyEntries[0].type);
-      expect(res.body.data.state).to.equal(propertyEntries[0].state);
-      expect(res.body.data.city).to.equal(propertyEntries[0].city);
       expect(res.body.data.price).to.equal(15000000);
-      expect(res.body.data.imageUrl).to.equal(propertyEntries[0].imageUrl);
+      expect(res.body.data.updatedOn).to.not.equal(null);
+    });
+
+    it('should update property ad type successfully', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[0].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('type', '3 bedroom duplex');
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('success');
+      expect(res.body).to.have.property('data');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.have.property('id');
+      expect(res.body.data).to.have.property('status');
+      expect(res.body.data).to.have.property('type');
+      expect(res.body.data).to.have.property('state');
+      expect(res.body.data).to.have.property('city');
+      expect(res.body.data).to.have.property('address');
+      expect(res.body.data).to.have.property('price');
+      expect(res.body.data).to.have.property('createdOn');
+      expect(res.body.data).to.have.property('updatedOn');
+      expect(res.body.data).to.have.property('imageUrl');
+      expect(res.body.data.type).to.equal('3 bedroom duplex');
+      expect(res.body.data.updatedOn).to.not.equal(null);
+    });
+
+    it('should update property ad state successfully', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[0].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('state', 'Oyo');
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('success');
+      expect(res.body).to.have.property('data');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.have.property('id');
+      expect(res.body.data).to.have.property('status');
+      expect(res.body.data).to.have.property('type');
+      expect(res.body.data).to.have.property('state');
+      expect(res.body.data).to.have.property('city');
+      expect(res.body.data).to.have.property('address');
+      expect(res.body.data).to.have.property('price');
+      expect(res.body.data).to.have.property('createdOn');
+      expect(res.body.data).to.have.property('updatedOn');
+      expect(res.body.data).to.have.property('imageUrl');
+      expect(res.body.data.state).to.equal('Oyo');
+      expect(res.body.data.updatedOn).to.not.equal(null);
+    });
+
+    it('should update property ad city successfully', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[0].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('city', 'Ibadan');
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('success');
+      expect(res.body).to.have.property('data');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.have.property('id');
+      expect(res.body.data).to.have.property('status');
+      expect(res.body.data).to.have.property('type');
+      expect(res.body.data).to.have.property('state');
+      expect(res.body.data).to.have.property('city');
+      expect(res.body.data).to.have.property('address');
+      expect(res.body.data).to.have.property('price');
+      expect(res.body.data).to.have.property('createdOn');
+      expect(res.body.data).to.have.property('updatedOn');
+      expect(res.body.data).to.have.property('imageUrl');
+      expect(res.body.data.city).to.equal('Ibadan');
+      expect(res.body.data.updatedOn).to.not.equal(null);
+    });
+
+    it('should update property ad price successfully', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[0].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('address', '13 Samonda Street');
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('success');
+      expect(res.body).to.have.property('data');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.have.property('id');
+      expect(res.body.data).to.have.property('status');
+      expect(res.body.data).to.have.property('type');
+      expect(res.body.data).to.have.property('state');
+      expect(res.body.data).to.have.property('city');
+      expect(res.body.data).to.have.property('address');
+      expect(res.body.data).to.have.property('price');
+      expect(res.body.data).to.have.property('createdOn');
+      expect(res.body.data).to.have.property('updatedOn');
+      expect(res.body.data).to.have.property('imageUrl');
+      expect(res.body.data.address).to.equal('13 Samonda Street');
       expect(res.body.data.updatedOn).to.not.equal(null);
     });
   });
@@ -249,6 +352,21 @@ export default () => {
         expect(res.body.error).to.equal('Invalid property id');
       });
 
+    it('should fail to update property ad with empty type', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('type', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('error');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.equal('Type cannot be empty');
+    });
+
     it('should fail to update property ad with empty state', async () => {
       const res = await chai.request(app)
         .patch(`${propertyUrl}/${propertyEntries[1].id}`)
@@ -326,12 +444,28 @@ export default () => {
       expect(res.body.error).to.equal('Address cannot be empty');
     });
 
+    it('should fail to update property ad with all number address field',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${agentOne.token}`)
+          .field('address', '876776577');
+
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Invalid address field');
+      });
+
     it('should fail to update property ad with empty price', async () => {
       const res = await chai.request(app)
         .patch(`${propertyUrl}/${propertyEntries[1].id}`)
         .set('Content-Type', 'multipart/form-data')
         .set('Authorization', `Bearer ${agentOne.token}`)
-        .field('address', '');
+        .field('price', '');
 
       expect(res.status).to.equal(400);
       expect(res.body).to.be.an('object');
@@ -363,7 +497,7 @@ export default () => {
           .patch(`${propertyUrl}/${propertyEntries[1].id}`)
           .set('Content-Type', 'multipart/form-data')
           .set('Authorization', `Bearer ${agentOne.token}`)
-          .field('address', '3928df');
+          .field('address', 0);
 
         expect(res.status).to.equal(400);
         expect(res.body).to.be.an('object');

--- a/server/test/update_property.test.js
+++ b/server/test/update_property.test.js
@@ -1,0 +1,376 @@
+import app from '../app';
+import testConfig from '../config/test_config';
+import users from '../db/users';
+import properties from '../db/properties';
+
+
+const { chai, expect } = testConfig;
+
+export default () => {
+  const propertyUrl = '/api/v1/property';
+  const signupUrl = '/api/v1/auth/signup';
+
+  // Test user objects
+  let agentOne = {
+    email: 'qauzeem@example.com',
+    firstName: 'Olawumi',
+    lastName: 'Yusuff',
+    password: '123456',
+    phoneNumber: '08000000000',
+    address: 'Iyana Ipaja, Lagos',
+    isAdmin: false,
+    isAgent: true,
+  };
+
+  let agentTwo = {
+    email: 'agent.two@example.com',
+    firstName: 'Bolu',
+    lastName: 'Olujide',
+    password: '123456',
+    phoneNumber: '08000000000',
+    address: 'Egbeda, Lagos',
+    isAdmin: false,
+    isAgent: true,
+  };
+
+  let user = {
+    email: 'user@example.com',
+    firstName: 'Olawumi',
+    lastName: 'Yusuff',
+    password: '123456',
+    phoneNumber: '08000000000',
+    address: 'Iyana Ipaja, Lagos',
+    isAdmin: false,
+    isAgent: false,
+  };
+
+  // Test property objects
+  const propertyEntries = [
+    {
+      type: '3 bedroom apartment',
+      state: 'Lagos',
+      city: 'Lagos',
+      address: '22 Allen Avenue, Ikeja',
+      price: 1000000.00,
+    },
+    {
+      type: 'mini flat',
+      state: 'Oyo',
+      city: 'Ibadan',
+      address: '11 Ologuneru Street, Samonda',
+      price: 8000000.00,
+    },
+  ];
+
+  // Sign up users and create property objects before tests
+  before((done) => {
+    chai.request(app)
+      .post(signupUrl)
+      .send(agentOne)
+      .then((res) => {
+        if (res.status === 201) {
+          agentOne = res.body.data;
+          return chai.request(app)
+            .post(signupUrl)
+            .send(agentTwo);
+        }
+        throw new Error('Could not sign agent up');
+      })
+      .then((res) => {
+        if (res.status === 201) {
+          agentTwo = res.body.data;
+          return chai.request(app)
+            .post(signupUrl)
+            .send(user);
+        }
+        throw new Error('Could not sign second agent up');
+      })
+      .then((res) => {
+        if (res.status === 201) {
+          user = res.body.data;
+          return chai.request(app)
+            .post(propertyUrl)
+            .set('Content-Type', 'multipart/form-data')
+            .set('Authorization', `Bearer ${agentOne.token}`)
+            .field('type', propertyEntries[0].type)
+            .field('state', propertyEntries[0].state)
+            .field('city', propertyEntries[0].city)
+            .field('address', propertyEntries[0].address)
+            .field('price', propertyEntries[0].price);
+        }
+        throw new Error('Could not sign up user');
+      })
+      .then((res) => {
+        if (res.status === 201) {
+          propertyEntries[0] = res.body.data;
+          return chai.request(app)
+            .post(propertyUrl)
+            .set('Content-Type', 'multipart/form-data')
+            .set('Authorization', `Bearer ${agentOne.token}`)
+            .field('type', propertyEntries[1].type)
+            .field('state', propertyEntries[1].state)
+            .field('city', propertyEntries[1].city)
+            .field('address', propertyEntries[1].address)
+            .field('price', propertyEntries[1].price);
+        }
+        throw new Error('Could not insert property item');
+      })
+      .then((res) => {
+        if (res.status === 201) {
+          propertyEntries[1] = res.body.data;
+          done();
+        } else {
+          throw new Error('Could not insert property item');
+        }
+      })
+      .catch(error => done(error));
+  });
+
+  // Clear records after
+  after((done) => {
+    users.splice(0);
+    properties.splice(0);
+    done();
+  });
+
+  describe('success', () => {
+    it('should update property ad data successfully', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[0].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('price', 15000000);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('success');
+      expect(res.body).to.have.property('data');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.have.property('id');
+      expect(res.body.data).to.have.property('status');
+      expect(res.body.data).to.have.property('type');
+      expect(res.body.data).to.have.property('state');
+      expect(res.body.data).to.have.property('city');
+      expect(res.body.data).to.have.property('address');
+      expect(res.body.data).to.have.property('price');
+      expect(res.body.data).to.have.property('createdOn');
+      expect(res.body.data).to.have.property('updatedOn');
+      expect(res.body.data).to.have.property('imageUrl');
+      expect(res.body.data.status).to.equal(propertyEntries[0].status);
+      expect(res.body.data.type).to.equal(propertyEntries[0].type);
+      expect(res.body.data.state).to.equal(propertyEntries[0].state);
+      expect(res.body.data.city).to.equal(propertyEntries[0].city);
+      expect(res.body.data.price).to.equal(15000000);
+      expect(res.body.data.imageUrl).to.equal(propertyEntries[0].imageUrl);
+      expect(res.body.data.updatedOn).to.not.equal(null);
+    });
+  });
+
+  // Tests that are meant to fail
+  describe('failure', () => {
+    it('should fail to update property data for an unauthorized user',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+          .set('Content-Type', 'multipart/form-data')
+          .field('price', 15000000);
+
+        expect(res.status).to.equal(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Unauthorized request');
+      });
+
+
+    it('should fail to update property ad for a non owner agent',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${agentTwo.token}`)
+          .field('price', 15000000);
+
+        expect(res.status).to.equal(403);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Only an advert owner (agent) can edit it');
+      });
+
+    it('should fail to update property ad for a non agent',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${user.token}`)
+          .field('price', 15000000);
+
+        expect(res.status).to.equal(403);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Only an advert owner (agent) can edit it');
+      });
+
+    it('should fail to update property ad for a non existing ad',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/9`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${agentOne.token}`)
+          .field('price', 15000000);
+
+        expect(res.status).to.equal(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Not found');
+      });
+
+    it('should fail to update property ad for an invalid property id',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/9jdkd`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${agentOne.token}`)
+          .field('price', 15000000);
+
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Invalid property id');
+      });
+
+    it('should fail to update property ad with empty state', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('state', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('error');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.equal('State cannot be empty');
+    });
+
+    it('should fail to update property ad with invalid state field',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${agentOne.token}`)
+          .field('state', '99 Oyo');
+
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Invalid state field');
+      });
+
+    it('should fail to update property ad with empty city', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('city', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('error');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.equal('City cannot be empty');
+    });
+
+    it('should fail to update property ad with invalid city field',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${agentOne.token}`)
+          .field('city', '99 Lagos');
+
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Invalid city field');
+      });
+
+    it('should fail to update property ad with empty address', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('address', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('error');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.equal('Address cannot be empty');
+    });
+
+    it('should fail to update property ad with empty price', async () => {
+      const res = await chai.request(app)
+        .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .set('Authorization', `Bearer ${agentOne.token}`)
+        .field('address', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('status');
+      expect(res.body.status).to.equal('error');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.equal('Invalid price field');
+    });
+
+    it('should fail to update property ad with invalid price',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${agentOne.token}`)
+          .field('address', '3928df');
+
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Invalid price field');
+      });
+
+    it('should fail to update property ad with zero price',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${agentOne.token}`)
+          .field('address', '3928df');
+
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Invalid price field');
+      });
+  });
+};


### PR DESCRIPTION
#### What does this PR do?
Provides the API endpoint from which an agent can update the details of his/her posted property adverts

#### Description of Task to be completed?
Have the following API endpoint working
PATCH /api/v1/property/<:propertyId>

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send PATCH requests to
  `/api/v1/property/<:propertyId>` on localhost
_key_: Port value: 3000
_key_: Content-Type value: multipart/form-data
_key_: Request body: all (or any) of type, price, state, city, address
_key_: Requires token authentication

#### Any background context you want to provide?
Agent should be able to update his/her posted property advert

#### What are the relevant pivotal tracker stories?
[#167060983](https://www.pivotaltracker.com/story/show/167060983)

#### Screenshots (if appropriate)
None

#### Questions:
None