### PR TITLE
#167161713 Integrate PostgreSQL with Create Property Endpoint

### DIFF
--- a/server/db/migration.js
+++ b/server/db/migration.js
@@ -37,8 +37,8 @@ const propertyTableCreationQuery = `
     city VARCHAR(50) NOT NULL,
     address VARCHAR(250) NOT NULL,
     price NUMERIC(19, 2) NOT NULL,
-    created_on VARCHAR(15) NOT NULL,
-    updated_on VARCHAR(15),
+    created_on VARCHAR(50) NOT NULL,
+    updated_on VARCHAR(50),
     image_url VARCHAR(200),
     owner BIGINT REFERENCES users (id) NOT NULL
   );
@@ -53,8 +53,8 @@ const propertyTestTableCreationQuery = `
     city VARCHAR(50) NOT NULL,
     address VARCHAR(250) NOT NULL,
     price NUMERIC(19, 2) NOT NULL,
-    created_on VARCHAR(15) NOT NULL,
-    updated_on VARCHAR(15),
+    created_on VARCHAR(50) NOT NULL,
+    updated_on VARCHAR(50),
     image_url VARCHAR(200),
     owner BIGINT REFERENCES users_test (id) NOT NULL
   );

--- a/server/helpers/auth.js
+++ b/server/helpers/auth.js
@@ -121,13 +121,13 @@ export const reformatUserData = (data) => {
 export const createUser = async ({
   email, firstName, lastName, phoneNumber, address, isAdmin, isAgent,
 }, hash, usersTable) => {
-  let userId;
+  // Get next database serial key
   const userIdQueryResult = await dbConnection.dbConnect(`SELECT nextval('${usersTable}_id_seq');`);
 
   if (userIdQueryResult.rowCount) {
-    userId = parseFloat(userIdQueryResult.rows[0].nextval);
-    const user = new User(userId, email, firstName, lastName, hash, phoneNumber || null,
-      address || null, isAdmin, isAgent);
+    const userId = parseFloat(userIdQueryResult.rows[0].nextval);
+    const user = new User(userId, email, firstName, lastName, hash, phoneNumber, address,
+      isAdmin, isAgent);
     user.token = getToken(email, userId);
     const userInsertQueryResult = await dbConnection.dbConnect(`INSERT INTO ${usersTable} (
       id, email, first_name, last_name, password, phone_number, address, is_admin, is_agent)

--- a/server/models/property.js
+++ b/server/models/property.js
@@ -1,16 +1,16 @@
 export default class Property {
   constructor(id, owner, type, state, city, address, price,
-    imageUrl = '', status = 'available') {
+    imageUrl) {
     this.id = id;
     this.owner = owner;
-    this.status = status;
+    this.status = 'available';
     this.type = type;
     this.state = state;
     this.city = city;
     this.address = address;
-    this.price = price;
-    this.createdOn = new Date();
+    this.price = parseFloat(parseFloat(price).toFixed(2));
+    this.createdOn = new Date().toLocaleString();
     this.updatedOn = null;
-    this.imageUrl = imageUrl;
+    this.imageUrl = imageUrl || '';
   }
 }

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,15 +1,15 @@
 export default class User {
-  constructor(id = null, email, firstName, lastName,
-    password, phoneNumber = null, address = null, isAdmin = false, isAgent = false) {
+  constructor(id, email, firstName, lastName, password, phoneNumber,
+    address, isAdmin, isAgent) {
     this.id = id;
     this.email = email;
     this.firstName = firstName;
     this.lastName = lastName;
     this.password = password;
-    this.phoneNumber = phoneNumber;
-    this.address = address;
-    this.isAdmin = isAdmin;
-    this.isAgent = isAgent;
+    this.phoneNumber = phoneNumber || null;
+    this.address = address || null;
+    this.isAdmin = isAdmin || false;
+    this.isAgent = isAgent || false;
     this.token = null;
   }
 }

--- a/server/test/create_property.test.js
+++ b/server/test/create_property.test.js
@@ -1,6 +1,5 @@
-import users from '../db/users';
-import properties from '../db/properties';
 import testConfig from '../config/test_config';
+import dbConnection from '../db/database';
 
 
 const { chai, expect, app } = testConfig;
@@ -60,9 +59,10 @@ export default () => {
 
   // Clear db records after tests run
   after((done) => {
-    users.splice(0);
-    properties.splice(0);
-    done();
+    dbConnection.dbConnect('DELETE FROM properties_test;')
+      .then(() => dbConnection.dbConnect('DELETE FROM users_test;'))
+      .then(() => done())
+      .catch(e => done(e));
   });
 
   // Tests that are meant to pass

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -26,8 +26,8 @@ describe('POST /api/v1/auth/signup', signupTests);
 // Tests for signin requests
 describe('POST /api/v1/auth/signin', signinTests);
 
-// // Tests for create property ad requests
-// describe('POST /api/v1/property', createPropertyAdTests);
+// Tests for create property ad requests
+describe('POST /api/v1/property', createPropertyAdTests);
 
 // // Tests for get all properties requests
 // describe('GET /api/v1/property', getAllPropertiesTests);


### PR DESCRIPTION
#### What does this PR do?
Integrate PostgreSQL database with create property endpoint **POST** `/api/v1/property`

#### Description of Task to be completed?
Insert new property advert data into database

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send POST requests to
  `/api/v1/property` on localhost
_key_: Port value: 3000
_key_: Content-Type value: multipart/form-data
_key_: Request body: type, state, city, address, price, propertyImage
_key_: Requires token authentication
_key_: Requires PostgreSQL connection

#### Any background context you want to provide?
Persist property advert data in database

#### What are the relevant pivotal tracker stories?
[#167161713](https://www.pivotaltracker.com/story/show/167161713)

#### Screenshots (if appropriate)
Not applicable

#### Questions:
None