### PR TITLE
#167165435 Integrate PostgreSQL to Get All Properties

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
     "rules": {
         "linebreak-style": 0,
         "consistent-return": 0,
+        "camelcase": 0,
     }
 };

--- a/server/controllers/property.js
+++ b/server/controllers/property.js
@@ -64,15 +64,17 @@ export const createProperty = (request, response) => {
  * @returns {response}
  */
 export const getProperties = (request, response) => {
-  const queryText = request.query.type;
+  // const queryText = request.query.type;
 
-  // Handle search queries by type
-  if (queryText !== undefined) {
-    return filterPropertiesByType(response, properties, queryText);
-  }
-
-  const data = properties.map(getPropertyDetails);
-  return ResponseHelper.getSuccessResponse(response, data);
+  // // Handle search queries by type
+  // if (queryText !== undefined) {
+  //   return filterPropertiesByType(response, properties, queryText);
+  // }
+  dbConnection.dbConnect(`SELECT * FROM ${propertiesTable};`)
+    .then(res => res.rows.map(ad => getPropertyDetails(ad, usersTable)))
+    .then(res => Promise.all(res))
+    .then(data => ResponseHelper.getSuccessResponse(response, data))
+    .catch(() => ResponseHelper.getInternalServerError());
 };
 
 

--- a/server/helpers/auth.js
+++ b/server/helpers/auth.js
@@ -76,7 +76,7 @@ export const getSignUpError = ({
  * @returns {object}
  */
 const getPublicUserData = user => ({
-  id: parseFloat(user.id),
+  id: user.id,
   email: user.email,
   firstName: user.firstName,
   lastName: user.lastName,
@@ -125,7 +125,7 @@ export const createUser = async ({
   const userIdQueryResult = await dbConnection.dbConnect(`SELECT nextval('${usersTable}_id_seq');`);
 
   if (userIdQueryResult.rowCount) {
-    const userId = parseFloat(userIdQueryResult.rows[0].nextval);
+    const userId = userIdQueryResult.rows[0].nextval;
     const user = new User(userId, email, firstName, lastName, hash, phoneNumber, address,
       isAdmin, isAgent);
     user.token = getToken(email, userId);

--- a/server/helpers/test_hooks_helper.js
+++ b/server/helpers/test_hooks_helper.js
@@ -1,0 +1,15 @@
+import dbConnection from '../db/database';
+
+
+export const clearAllTestRecords = (done) => {
+  dbConnection.dbConnect('DELETE FROM properties_test;')
+    .then(() => dbConnection.dbConnect('DELETE FROM users_test;'))
+    .then(() => done())
+    .catch(e => done(e));
+};
+
+export const clearTestUsersRecords = (done) => {
+  dbConnection.dbConnect('DELETE FROM users_test;')
+    .then(() => done())
+    .catch(e => done(e));
+};

--- a/server/models/property.js
+++ b/server/models/property.js
@@ -8,7 +8,7 @@ export default class Property {
     this.state = state;
     this.city = city;
     this.address = address;
-    this.price = parseFloat(parseFloat(price).toFixed(2));
+    this.price = parseFloat(price).toFixed(2);
     this.createdOn = new Date().toLocaleString();
     this.updatedOn = null;
     this.imageUrl = imageUrl || '';

--- a/server/test/create_property.test.js
+++ b/server/test/create_property.test.js
@@ -106,7 +106,7 @@ export default () => {
       expect(res.body.data.type).to.equal(data.type);
       expect(res.body.data.state).to.equal(data.state);
       expect(res.body.data.city).to.equal(data.city);
-      expect(res.body.data.price).to.equal(data.price);
+      expect(res.body.data.price).to.equal(data.price.toFixed(2));
       expect(res.body.data.imageUrl).to.not.equal('');
     });
 
@@ -148,7 +148,7 @@ export default () => {
       expect(res.body.data.type).to.equal(data.type);
       expect(res.body.data.state).to.equal(data.state);
       expect(res.body.data.city).to.equal(data.city);
-      expect(res.body.data.price).to.equal(data.price);
+      expect(res.body.data.price).to.equal(data.price.toFixed(2));
     });
   });
 

--- a/server/test/create_property.test.js
+++ b/server/test/create_property.test.js
@@ -1,5 +1,5 @@
 import testConfig from '../config/test_config';
-import dbConnection from '../db/database';
+import { clearAllTestRecords } from '../helpers/test_hooks_helper';
 
 
 const { chai, expect, app } = testConfig;
@@ -58,12 +58,7 @@ export default () => {
   });
 
   // Clear db records after tests run
-  after((done) => {
-    dbConnection.dbConnect('DELETE FROM properties_test;')
-      .then(() => dbConnection.dbConnect('DELETE FROM users_test;'))
-      .then(() => done())
-      .catch(e => done(e));
-  });
+  after(clearAllTestRecords);
 
   // Tests that are meant to pass
   describe('success', () => {

--- a/server/test/get_all_properties.test.js
+++ b/server/test/get_all_properties.test.js
@@ -137,6 +137,7 @@ export default () => {
       expect(res.body.data[0]).to.have.property('ownerName');
       expect(res.body.data[0]).to.have.property('ownerEmail');
       expect(res.body.data[0]).to.have.property('ownerPhoneNumber');
+      expect(res.body.data[0]).to.have.property('ownerAddress');
       expect(res.body.data[0].id).to.equal(propertyEntries[0].id);
       expect(res.body.data[0].status).to.equal(propertyEntries[0].status);
       expect(res.body.data[0].type).to.equal(propertyEntries[0].type);
@@ -148,6 +149,7 @@ export default () => {
       expect(res.body.data[0].ownerName).to.equal(`${agent.firstName} ${agent.lastName}`);
       expect(res.body.data[0].ownerEmail).to.equal(agent.email);
       expect(res.body.data[0].ownerPhoneNumber).to.equal(agent.phoneNumber);
+      expect(res.body.data[0].ownerAddress).to.equal(agent.address);
       expect(res.body.data[1]).to.have.property('id');
       expect(res.body.data[1]).to.have.property('status');
       expect(res.body.data[1]).to.have.property('type');
@@ -161,6 +163,7 @@ export default () => {
       expect(res.body.data[1]).to.have.property('ownerName');
       expect(res.body.data[1]).to.have.property('ownerEmail');
       expect(res.body.data[1]).to.have.property('ownerPhoneNumber');
+      expect(res.body.data[1]).to.have.property('ownerAddress');
       expect(res.body.data[1].id).to.equal(propertyEntries[1].id);
       expect(res.body.data[1].status).to.equal(propertyEntries[1].status);
       expect(res.body.data[1].type).to.equal(propertyEntries[1].type);
@@ -172,6 +175,7 @@ export default () => {
       expect(res.body.data[1].ownerName).to.equal(`${agent.firstName} ${agent.lastName}`);
       expect(res.body.data[1].ownerEmail).to.equal(agent.email);
       expect(res.body.data[1].ownerPhoneNumber).to.equal(agent.phoneNumber);
+      expect(res.body.data[1].ownerAddress).to.equal(agent.address);
     });
   });
 

--- a/server/test/get_all_properties.test.js
+++ b/server/test/get_all_properties.test.js
@@ -1,6 +1,5 @@
-import users from '../db/users';
-import properties from '../db/properties';
 import testConfig from '../config/test_config';
+import { clearAllTestRecords } from '../helpers/test_hooks_helper';
 
 
 const { chai, expect, app } = testConfig;
@@ -109,11 +108,7 @@ export default () => {
   });
 
   // Clear all db records after tests run
-  after((done) => {
-    properties.splice(0);
-    users.splice(0);
-    done();
-  });
+  after(clearAllTestRecords);
 
   describe('success', () => {
     it('should get all properties ads', async () => {

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -16,6 +16,7 @@ before((done) => {
     .then(() => {
       return dbConnection.dbConnect('ALTER SEQUENCE users_test_id_seq RESTART WITH 1;');
     })
+    .then(() => dbConnection.dbConnect('ALTER SEQUENCE properties_test_id_seq RESTART WITH 1;'))
     .then(() => done())
     .catch(e => done(e));
 });

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -18,7 +18,7 @@ before((done) => {
     })
     .then(() => done())
     .catch(e => done(e));
-})
+});
 
 // Tests for signup requests
 describe('POST /api/v1/auth/signup', signupTests);

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -29,8 +29,8 @@ describe('POST /api/v1/auth/signin', signinTests);
 // Tests for create property ad requests
 describe('POST /api/v1/property', createPropertyAdTests);
 
-// // Tests for get all properties requests
-// describe('GET /api/v1/property', getAllPropertiesTests);
+// Tests for get all properties requests
+describe('GET /api/v1/property', getAllPropertiesTests);
 
 // // Tests for get property by id requests
 // describe('GET /api/v1/property/<:propertyId>', getPropertyByIdTests);

--- a/server/test/signin.test.js
+++ b/server/test/signin.test.js
@@ -1,9 +1,8 @@
 import testConfig from '../config/test_config';
-import dbConnection from '../db/database';
+import { clearTestUsersRecords } from '../helpers/test_hooks_helper';
+
 
 const { chai, expect, app } = testConfig;
-
-
 const signinUrl = '/api/v1/auth/signin';
 
 export default () => {
@@ -36,11 +35,7 @@ export default () => {
   });
 
   // Clear user db after tests run
-  after((done) => {
-    dbConnection.dbConnect('DELETE FROM users_test;')
-      .then(() => done())
-      .catch(e => done(e));
-  });
+  after(clearTestUsersRecords);
 
 
   // Tests that are meant to pass

--- a/server/test/signup.test.js
+++ b/server/test/signup.test.js
@@ -1,9 +1,9 @@
 import testConfig from '../config/test_config';
 import dbConnection from '../db/database';
-import app from '../app';
+import { clearTestUsersRecords } from '../helpers/test_hooks_helper';
 
 
-const { chai, expect } = testConfig;
+const { chai, expect, app } = testConfig;
 const signupUrl = '/api/v1/auth/signup';
 
 
@@ -44,11 +44,7 @@ export default () => {
   });
 
   // Clear the db after
-  after((done) => {
-    dbConnection.dbConnect('DELETE FROM users_test;')
-      .then(() => done())
-      .catch(e => done(e));
-  });
+  after(clearTestUsersRecords);
 
   // Tests that are meant to pass
   describe('success', () => {


### PR DESCRIPTION
#### What does this PR do?
Fetch persisted property adverts from PostgreSQL database

#### Description of Task to be completed?
Integrate PostgreSQL database with endpoint **GET** `/api/v1/property`

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send GET requests to
  `/api/v1/property` on localhost
_key_: Port value: 3000
_key_: Requires token authentication

#### Any background context you want to provide?
Property adverts data should be fetched from database

#### What are the relevant pivotal tracker stories?
[#167165435](https://www.pivotaltracker.com/story/show/167165435)

#### Screenshots (if appropriate)
Not applicable

#### Questions:
None