### PR TITLE
#167165558 Integrate PostgreSQL with Search Properties Endpoint

### DIFF
--- a/server/controllers/property.js
+++ b/server/controllers/property.js
@@ -64,12 +64,14 @@ export const createProperty = (request, response) => {
  * @returns {response}
  */
 export const getProperties = (request, response) => {
-  // const queryText = request.query.type;
+  const queryText = request.query.type;
 
-  // // Handle search queries by type
-  // if (queryText !== undefined) {
-  //   return filterPropertiesByType(response, properties, queryText);
-  // }
+  // Handle search queries by type
+  if (queryText !== undefined) {
+    return filterPropertiesByType(response, queryText, propertiesTable, usersTable)
+      .then(res => res)
+      .catch(() => ResponseHelper.getInternalServerError(response));
+  }
   dbConnection.dbConnect(`SELECT * FROM ${propertiesTable};`)
     .then(res => res.rows.map(ad => getPropertyDetails(ad, usersTable)))
     .then(res => Promise.all(res))

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -40,7 +40,7 @@ describe('GET /api/v1/property', getAllPropertiesTests);
 // describe('PATCH /api/v1/property/<:propertyId>/sold', markPropertyAsSoldTests);
 
 // // Tests for property list search
-// describe('GET /api/v1/property?type=queryText', queryPropertyTypeTests);
+describe('GET /api/v1/property?type=propertyType', queryPropertyTypeTests);
 
 // // Tests for property update
 // describe('PATCH /api/v1/property/<:propertyId>', updatePropertyAdTests);

--- a/server/test/search_property_by_type.test.js
+++ b/server/test/search_property_by_type.test.js
@@ -1,6 +1,5 @@
 import testConfig from '../config/test_config';
-import properties from '../db/properties';
-import users from '../db/users';
+import { clearAllTestRecords } from '../helpers/test_hooks_helper';
 
 const { chai, expect, app } = testConfig;
 
@@ -149,11 +148,7 @@ export default () => {
       .catch(error => done(error));
   });
 
-  after((done) => {
-    properties.splice(0);
-    users.splice(0);
-    done();
-  });
+  after(clearAllTestRecords);
 
   describe('success', () => {
     it('should get properties of same type irrespective of case', async () => {


### PR DESCRIPTION
#### What does this PR do?
Integrate PostgreSQL database with endpoint **GET** `/api/v1/property?type=propertyType`

#### Description of Task to be completed?
Filter database records with query text

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send GET requests to
  `/api/v1/property?type=propertyType` on localhost
_key_: Port value: 3000
_key_: Content-Type: application/x-www-form-urlencoded
_key_: Requires token authentication

#### Any background context you want to provide?
User should be able to filter properties by type

#### What are the relevant pivotal tracker stories?
[#167165558](https://www.pivotaltracker.com/story/show/167165558)

#### Screenshots (if appropriate)
Not applicable

#### Questions:
None