### PR TITLE
#167162051 Connect Endpoint to Mark Property as Sold with Database

### DIFF
--- a/server/helpers/property.js
+++ b/server/helpers/property.js
@@ -198,3 +198,26 @@ export const dbInsertNewProperty = async ({
     } throw new Error();
   } else throw new Error();
 };
+
+
+/**
+ * Updates database property record's status
+ * @param {*} response
+ * @param {string} propertiesTable
+ * @param {number string} propertyId
+ * @param {string} usersTable
+ *
+ * @returns {response} or @throws {Error}
+ */
+export const dbMarkPropertyAsSold = async (response, propertiesTable, propertyId, usersTable) => {
+  const updateTime = new Date().toLocaleString();
+  const updateRes = await dbConnection.dbConnect(`UPDATE ${propertiesTable} SET status='sold',
+    updated_on= $1 WHERE id = $2`, [updateTime, propertyId]);
+  if (updateRes.rowCount) {
+    return dbConnection.dbConnect(`SELECT * FROM ${propertiesTable} WHERE id = $1;`,
+      [propertyId])
+      .then(selectRes => getPropertyDetails(selectRes.rows[0], usersTable)
+        .then(data => () => ResponseHelper.getSuccessResponse(response, data)));
+  }
+  return (() => { throw new Error(); });
+};

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -36,8 +36,8 @@ describe('GET /api/v1/property', getAllPropertiesTests);
 // Tests for get property by id requests
 describe('GET /api/v1/property/<:propertyId>', getPropertyByIdTests);
 
-// // Tests for marking a property ad as sold
-// describe('PATCH /api/v1/property/<:propertyId>/sold', markPropertyAsSoldTests);
+// Tests for marking a property ad as sold
+describe('PATCH /api/v1/property/<:propertyId>/sold', markPropertyAsSoldTests);
 
 // // Tests for property list search
 describe('GET /api/v1/property?type=propertyType', queryPropertyTypeTests);

--- a/server/test/mark_sold.test.js
+++ b/server/test/mark_sold.test.js
@@ -136,7 +136,7 @@ export default () => {
       .then((res) => {
         if (res.rowCount) {
           return dbConnection.dbConnect("UPDATE properties_test SET status='available' WHERE id = $1",
-            [propertyEntries[0].id])
+            [propertyEntries[0].id]);
         }
         throw new Error('Could not reset property status');
       })


### PR DESCRIPTION
#### What does this PR do?
Connect PostgreSQL database with endpoint **PATCH** `/api/v1/property/<:propertyId>/sold`

#### Description of Task to be completed?
Update property status in persisted database

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send PATCH requests to
  `/api/v1/property/<:propertyId>/sold` on localhost
_key_: Port value: 3000
_key_: Requires token authentication

#### Any background context you want to provide?
An agent should be able to mark his/her posted property advert as sold and have the persisted

#### What are the relevant pivotal tracker stories?
[#167162051](https://www.pivotaltracker.com/story/show/167162051)

#### Screenshots (if appropriate)
Not applicable

#### Questions:
None