### PR TITLE
#167161835 Integrate PostgreSQL with Property Update Endpoint

### DIFF
--- a/server/middleware/server_error_handler.js
+++ b/server/middleware/server_error_handler.js
@@ -1,0 +1,14 @@
+/**
+ * Handles errors with request body processing
+ * @returns {response} if there was an error
+ * Calls @function next if no error
+ */
+export default (error, request, response, next) => {
+  if (error) {
+    return response.status(500).json({
+      status: 'error',
+      error: 'Internal server error',
+    });
+  }
+  next();
+};

--- a/server/routes/property.js
+++ b/server/routes/property.js
@@ -4,6 +4,7 @@ import * as propertyController from '../controllers/property';
 import checkAuth from '../middleware/check_auth';
 import imageUploader from '../middleware/image_upload';
 import validatePropertyId from '../middleware/validate_property_id';
+import serverErrorHandlerMiddleware from '../middleware/server_error_handler';
 
 
 const router = Router();
@@ -19,7 +20,7 @@ router.patch('/:propertyId/sold', checkAuth, validatePropertyId,
   propertyController.markPropertyAsSold);
 
 router.patch('/:propertyId', checkAuth, validatePropertyId,
-  imageUploader, propertyController.updateProperty);
+  imageUploader, serverErrorHandlerMiddleware, propertyController.updateProperty);
 
 router.delete('/:propertyId', checkAuth, validatePropertyId,
   propertyController.deleteProperty);

--- a/server/test/create_property.test.js
+++ b/server/test/create_property.test.js
@@ -401,7 +401,7 @@ export default () => {
         expect(res.body).to.have.property('status');
         expect(res.body.status).to.equal('error');
         expect(res.body).to.have.property('error');
-        expect(res.body.error).to.equal('Invalid price field');
+        expect(res.body.error).to.equal('Invalid, zero or empty price field');
       });
 
     it('should fail to create a new property ad due to zero price',
@@ -429,7 +429,7 @@ export default () => {
         expect(res.body).to.have.property('status');
         expect(res.body.status).to.equal('error');
         expect(res.body).to.have.property('error');
-        expect(res.body.error).to.equal('Invalid price field');
+        expect(res.body.error).to.equal('Invalid, zero or empty price field');
       });
   });
 };

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -42,8 +42,8 @@ describe('PATCH /api/v1/property/<:propertyId>/sold', markPropertyAsSoldTests);
 // // Tests for property list search
 describe('GET /api/v1/property?type=propertyType', queryPropertyTypeTests);
 
-// // Tests for property update
-// describe('PATCH /api/v1/property/<:propertyId>', updatePropertyAdTests);
+// Tests for property update
+describe('PATCH /api/v1/property/<:propertyId>', updatePropertyAdTests);
 
 // // Tests for property delete
 // describe('DELETE /api/v1/property/<:propertyId>', deletePropertyAdTests);

--- a/server/test/update_property.test.js
+++ b/server/test/update_property.test.js
@@ -1,6 +1,5 @@
 import testConfig from '../config/test_config';
-import users from '../db/users';
-import properties from '../db/properties';
+import { clearAllTestRecords } from '../helpers/test_hooks_helper';
 
 
 const { chai, expect, app } = testConfig;
@@ -126,11 +125,7 @@ export default () => {
   });
 
   // Clear records after
-  after((done) => {
-    users.splice(0);
-    properties.splice(0);
-    done();
-  });
+  after(clearAllTestRecords);
 
   describe('success', () => {
     it('should update property ad price successfully', async () => {

--- a/server/test/update_property.test.js
+++ b/server/test/update_property.test.js
@@ -129,11 +129,12 @@ export default () => {
 
   describe('success', () => {
     it('should update property ad price successfully', async () => {
+      const newPrice = 15000000;
       const res = await chai.request(app)
         .patch(`${propertyUrl}/${propertyEntries[0].id}`)
         .set('Content-Type', 'multipart/form-data')
         .set('Authorization', `Bearer ${agentOne.token}`)
-        .field('price', 15000000);
+        .field('price', newPrice);
 
       expect(res.status).to.equal(200);
       expect(res.body).to.be.an('object');
@@ -151,7 +152,7 @@ export default () => {
       expect(res.body.data).to.have.property('createdOn');
       expect(res.body.data).to.have.property('updatedOn');
       expect(res.body.data).to.have.property('imageUrl');
-      expect(res.body.data.price).to.equal(15000000);
+      expect(res.body.data.price).to.equal(newPrice.toFixed(2));
       expect(res.body.data.updatedOn).to.not.equal(null);
     });
 
@@ -236,7 +237,7 @@ export default () => {
       expect(res.body.data.updatedOn).to.not.equal(null);
     });
 
-    it('should update property ad price successfully', async () => {
+    it('should update property address successfully', async () => {
       const res = await chai.request(app)
         .patch(`${propertyUrl}/${propertyEntries[0].id}`)
         .set('Content-Type', 'multipart/form-data')

--- a/server/test/update_property.test.js
+++ b/server/test/update_property.test.js
@@ -289,12 +289,12 @@ export default () => {
           .set('Content-Type', 'multipart/form-data')
           .set('Authorization', `Bearer ${agentOne.token}`)
 
-        expect(res.status).to.equal(400);
+        expect(res.status).to.equal(500);
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.property('status');
         expect(res.body.status).to.equal('error');
         expect(res.body).to.have.property('error');
-        expect(res.body.error).to.equal('Empty request');
+        expect(res.body.error).to.equal('Internal server error');
       });
 
 

--- a/server/test/update_property.test.js
+++ b/server/test/update_property.test.js
@@ -282,6 +282,22 @@ export default () => {
       });
 
 
+    it('should fail for an empty request body',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${propertyUrl}/${propertyEntries[1].id}`)
+          .set('Content-Type', 'multipart/form-data')
+          .set('Authorization', `Bearer ${agentOne.token}`)
+
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.equal('Empty request');
+      });
+
+
     it('should fail to update property ad for a non owner agent',
       async () => {
         const res = await chai.request(app)
@@ -466,7 +482,7 @@ export default () => {
       expect(res.body).to.have.property('status');
       expect(res.body.status).to.equal('error');
       expect(res.body).to.have.property('error');
-      expect(res.body.error).to.equal('Invalid price field');
+      expect(res.body.error).to.equal('Invalid, zero or empty price field');
     });
 
     it('should fail to update property ad with invalid price',
@@ -482,7 +498,7 @@ export default () => {
         expect(res.body).to.have.property('status');
         expect(res.body.status).to.equal('error');
         expect(res.body).to.have.property('error');
-        expect(res.body.error).to.equal('Invalid price field');
+        expect(res.body.error).to.equal('Invalid, zero or empty price field');
       });
 
     it('should fail to update property ad with zero price',
@@ -498,7 +514,7 @@ export default () => {
         expect(res.body).to.have.property('status');
         expect(res.body.status).to.equal('error');
         expect(res.body).to.have.property('error');
-        expect(res.body.error).to.equal('Invalid price field');
+        expect(res.body.error).to.equal('Invalid, zero or empty price field');
       });
 
     it('should fail to update property id', async () => {


### PR DESCRIPTION
#### What does this PR do?
Integrates  endpoint **PATCH** `/api/v1/property/<:propertyId>` with PostgreSQL database

#### Description of Task to be completed?
Replace database-persisted property data with new data

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send PATCH requests to
  `/api/v1/property/<:propertyId>` on localhost
_key_: Port value: 3000
_key_: Content-Type value: mulitpart/form-data
_key_: Request body: any of price, type, state, city, address
_key_: Requires token authentication

#### Any background context you want to provide?
An agent should be able to update property and have the data replace previous persisted data

#### What are the relevant pivotal tracker stories?
[#167161835](https://www.pivotaltracker.com/story/show/167161835)

#### Screenshots (if appropriate)
Not applicable

#### Questions:
None