### PR TITLE
#167164866 Integrate PostgreSQL with Delete Property Endpoint

### DIFF
--- a/server/db/properties.js
+++ b/server/db/properties.js
@@ -1,1 +1,0 @@
-export default [];

--- a/server/db/users.js
+++ b/server/db/users.js
@@ -1,1 +1,0 @@
-export default [];

--- a/server/helpers/property.js
+++ b/server/helpers/property.js
@@ -268,3 +268,15 @@ export const dbUpdateProperty = async (response, body, propertiesTable,
       return (() => { throw new Error(); });
     });
 };
+
+
+export const dbDeleteProperty = async (response, propertyId, propertiesTable) => dbConnection
+  .dbConnect(`DELETE FROM ${propertiesTable} WHERE id = $1;`, [propertyId])
+  .then((res) => {
+    if (res.rowCount) {
+      return (() => ResponseHelper.getSuccessResponse(response, {
+        message: 'Successfully deleted property ad',
+      }));
+    }
+    return (() => { throw new Error(); });
+  });

--- a/server/helpers/test_hooks_helper.js
+++ b/server/helpers/test_hooks_helper.js
@@ -1,6 +1,11 @@
 import dbConnection from '../db/database';
 
 
+/**
+ * Cleans up the test users table preventing it from being littered as
+ * well ensuring consistent behaviour between tests
+ * @param {callback} done
+ */
 export const clearAllTestRecords = (done) => {
   dbConnection.dbConnect('DELETE FROM properties_test;')
     .then(() => dbConnection.dbConnect('DELETE FROM users_test;'))
@@ -8,6 +13,11 @@ export const clearAllTestRecords = (done) => {
     .catch(e => done(e));
 };
 
+/**
+ * Cleans up the test users and properties tables preventing it from being littered as
+ * well ensuring consistent behaviour between tests
+ * @param {callback} done
+ */
 export const clearTestUsersRecords = (done) => {
   dbConnection.dbConnect('DELETE FROM users_test;')
     .then(() => done())

--- a/server/test/delete_property.test.js
+++ b/server/test/delete_property.test.js
@@ -1,6 +1,4 @@
 import testConfig from '../config/test_config';
-import users from '../db/users';
-import properties from '../db/properties';
 import { clearAllTestRecords } from '../helpers/test_hooks_helper';
 
 
@@ -147,7 +145,6 @@ export default () => {
       expect(res.body.data).to.be.an('object');
       expect(res.body.data).to.have.property('message');
       expect(res.body.data.message).to.equal('Successfully deleted property ad');
-      expect(properties.length).to.equal(1);
     });
   });
 

--- a/server/test/delete_property.test.js
+++ b/server/test/delete_property.test.js
@@ -1,6 +1,7 @@
 import testConfig from '../config/test_config';
 import users from '../db/users';
 import properties from '../db/properties';
+import { clearAllTestRecords } from '../helpers/test_hooks_helper';
 
 
 const { chai, expect, app } = testConfig;
@@ -127,11 +128,7 @@ export default () => {
   });
 
   // Clear records after
-  after((done) => {
-    users.splice(0);
-    properties.splice(0);
-    done();
-  });
+  after(clearAllTestRecords);
 
 
   // Tests that are meant to pass

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -13,9 +13,7 @@ import deletePropertyAdTests from './delete_property.test';
 
 before((done) => {
   Migration.createTestTables()
-    .then(() => {
-      return dbConnection.dbConnect('ALTER SEQUENCE users_test_id_seq RESTART WITH 1;');
-    })
+    .then(() => dbConnection.dbConnect('ALTER SEQUENCE users_test_id_seq RESTART WITH 1;'))
     .then(() => dbConnection.dbConnect('ALTER SEQUENCE properties_test_id_seq RESTART WITH 1;'))
     .then(() => done())
     .catch(e => done(e));

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -46,4 +46,4 @@ describe('GET /api/v1/property?type=propertyType', queryPropertyTypeTests);
 describe('PATCH /api/v1/property/<:propertyId>', updatePropertyAdTests);
 
 // // Tests for property delete
-// describe('DELETE /api/v1/property/<:propertyId>', deletePropertyAdTests);
+describe('DELETE /api/v1/property/<:propertyId>', deletePropertyAdTests);

--- a/server/test/update_property.test.js
+++ b/server/test/update_property.test.js
@@ -288,7 +288,7 @@ export default () => {
         const res = await chai.request(app)
           .patch(`${propertyUrl}/${propertyEntries[1].id}`)
           .set('Content-Type', 'multipart/form-data')
-          .set('Authorization', `Bearer ${agentOne.token}`)
+          .set('Authorization', `Bearer ${agentOne.token}`);
 
         expect(res.status).to.equal(500);
         expect(res.body).to.be.an('object');


### PR DESCRIPTION
#### What does this PR do?
Integrates endpoint **DELETE** `/api/v1/property/<:propertyId>` with PostgreSQL database

#### Description of Task to be completed?
Delete property advert from database records

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send DELETE requests to
  `/api/v1/property/<:propertyId>` on localhost
_key_: Port value: 3000
_key_: Requires token authentication

#### Any background context you want to provide?
Agent should be able to delete a property advert and have it removed from database records

#### What are the relevant pivotal tracker stories?
[#167164866](https://www.pivotaltracker.com/story/show/167164866)

#### Screenshots (if appropriate)
Not applicable

#### Questions:
None