### PR TITLE
#167417954 Fix Wrong Signin Specification in Documentation

### DIFF
--- a/server/swagger.json
+++ b/server/swagger.json
@@ -9,7 +9,7 @@
     },
     "license": {
       "name": "MIT",
-      "url": "propertyprolite-api.herokuapp.com"
+      "url": "localhost:3000"
     }
   },
   "host": "",
@@ -91,11 +91,11 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "Success"
           },
-          "400": {
-            "description": "Invalid field(s), empty required field(s) or non existing account"
+          "401": {
+            "description": "Unauthorized"
           },
           "500": {
             "description": "Server error"

--- a/server/v1/controllers/auth.js
+++ b/server/v1/controllers/auth.js
@@ -53,7 +53,7 @@ export const signup = (request, response) => {
  * @param response
  */
 export const signin = (request, response) => {
-  const signinErrorMessage = 'Incorrect email or password';
+  const signinErrorMessage = 'Invalid email or password';
   const { email, password } = request.body;
 
   if (!isValidEmail(email) || !isValidPassword(password)) {

--- a/server/v1/controllers/auth.js
+++ b/server/v1/controllers/auth.js
@@ -53,7 +53,7 @@ export const signup = (request, response) => {
  * @param response
  */
 export const signin = (request, response) => {
-  const signinErrorMessage = 'Invalid email or password';
+  const signinErrorMessage = 'Incorrect email or password';
   const { email, password } = request.body;
 
   if (!isValidEmail(email) || !isValidPassword(password)) {


### PR DESCRIPTION
#### What does this PR do?
Correct wrongly specified response code for successful signins on the documentation page

#### Description of Task to be completed?
Edit the swagger document

#### How should this be manually tested?
Clone this repo, cd into it and run `npm run server`
- Open URL `/api-docs` (the documentation page) in a browser
- Enter valid signin credentials for an existing account
_key_: Port value: 3000
_key_: Content-Type value: application/json
_key_: Request body: email, password

#### Any background context you want to provide?
Documentation should be comprehensive and correct

#### What are the relevant pivotal tracker stories?
[#167417954](https://www.pivotaltracker.com/story/show/167417954)

#### Screenshots (if appropriate)
Not applicable

#### Questions:
None